### PR TITLE
Add command argument `project`, which is used as a target folder

### DIFF
--- a/lib/coa.js
+++ b/lib/coa.js
@@ -43,12 +43,19 @@ module.exports = require('coa').Cmd()
         .long('force-latest')
         .flag()
         .end()
+    .arg()
+        .name('project').title('Project path to install dependencies for (default is cwd)')
+        .def(process.cwd())
+        .val(function(val) {
+            return PATH.resolve(process.cwd(), val);
+        })
+        .end()
     .completable()
-    .act(function(opts) {
+    .act(function(opts, args) {
         var defer = Q.defer(),
             config = {
                 verbose: false,
-                cwd: process.cwd(),
+                cwd: args.project,
                 color: true
             },
             renderer = new StandardRenderer('install', config);


### PR DESCRIPTION
Add command argument `project`, which is used as a target folder for dependencies installation, instead of hardcoded `process.cwd()`. `process.cwd()` value is used when the argument is ommited.
