### PR TITLE
Only run npm install if Gruntfile exists

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -94,7 +94,7 @@ function npmInstallAll(list, options, config) {
             var path = dep.path;
             promise = promise
                 .then(function() {
-                    return QFS.exists(PATH.join(path, 'package.json'))
+                    return QFS.exists(PATH.join(path, 'Gruntfile'))
                         .then(function(isPackage) {
                             if (!isPackage) return;
 


### PR DESCRIPTION
Some mainstream libraries like requireJS will crash if you run npm install. How about we do QFS.exists for Gruntfile instead of package.json?
