### PR TITLE
Add --npm-args option

### DIFF
--- a/lib/coa.js
+++ b/lib/coa.js
@@ -49,6 +49,12 @@ module.exports = require('coa').Cmd()
         .long('non-interactive')
         .flag()
         .end()
+    .opt()
+        .name('npm-args')
+        .title('Pass options specified in ' + C.yellow('npm-args') + ' to ' + C.blueBright('npm install'))
+        .long('npm-args')
+        .arr()
+        .end()
     .completable()
     .act(function(opts) {
         var defer = Q.defer(),

--- a/lib/install.js
+++ b/lib/install.js
@@ -86,6 +86,10 @@ function npmInstallAll(list, options, config) {
         npmArgs = ['install', options['npm-development'] ? '--development' : '--production'],
         promise = Q.resolve();
 
+    if (options['npm-args']) {
+        npmArgs = npmArgs.concat(options['npm-args']);
+    }
+
     Object.keys(list)
         .map(function(key) {
             return {


### PR DESCRIPTION
Add new option "npm-args". Using it you can pass any option to npm like this 

```
bower-npm-install --npm-args="--no-bin-links" --npm-args="--verbose"
```

The reason for this option is described here https://github.com/arikon/bower-npm-install/issues/14
